### PR TITLE
Add condition constant to indicate item template file not ready

### DIFF
--- a/api/v1alpha1/condition_constants.go
+++ b/api/v1alpha1/condition_constants.go
@@ -22,4 +22,5 @@ const (
 const (
 	ClusterContentLibraryRefValidationFailedReason = "ClusterContentLibraryRefValidationFailed"
 	ContentLibraryRefValidationFailedReason        = "ContentLibraryRefValidationFailed"
+	ContentLibraryItemFileUnavailableReason        = "ContentLibraryItemFileUnavailable"
 )


### PR DESCRIPTION
Story: https://jira.eng.vmware.com/browse/VKAL-18475

The ClusterContentLibraryItem and ContentLibraryItem does not have a ready field in status, but the conditions will have a ready status which indicates if the library item is ready to be used and the template is ready for consumption by other services. Until, the template is ready for consumption, the ready condition should be set to false.

This change adds the Condition.Reason which indicates that the ClusterContentLibraryItem and ContentLibraryItem resources are marked as NotReady because the template files are not available.