### PR TITLE
Fix cclitem printcolumn clref

### DIFF
--- a/api/v1alpha1/condition_constants.go
+++ b/api/v1alpha1/condition_constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/api/v1alpha1/contentlibraryitem_types.go
+++ b/api/v1alpha1/contentlibraryitem_types.go
@@ -201,7 +201,7 @@ func (cclItem *ClusterContentLibraryItem) SetConditions(conditions Conditions) {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=cclitem
 // +kubebuilder:printcolumn:name="vSphereName",type="string",JSONPath=".status.name"
-// +kubebuilder:printcolumn:name="ClusterContentLibraryRef",type="string",JSONPath=".status.contentLibraryRef.Name"
+// +kubebuilder:printcolumn:name="ClusterContentLibraryRef",type="string",JSONPath=".status.contentLibraryRef.name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Cached",type="boolean",JSONPath=".status.cached"


### PR DESCRIPTION
Fix the bug in cluster content library CR content library reference print column value
and update copyright year in the condition_constants.go file.