### PR TITLE
Add default value for the allowImport spec field in CL CRD

### DIFF
--- a/api/v1alpha1/contentlibrary_types.go
+++ b/api/v1alpha1/contentlibrary_types.go
@@ -85,6 +85,7 @@ type ContentLibrarySpec struct {
 	// AllowImport flag indicates if users can import OVF/OVA templates from remote HTTPS URLs
 	// as new content library items in this library.
 	// +optional
+	// +kubebuilder:default=false
 	AllowImport bool `json:"allowImport,omitempty"`
 }
 


### PR DESCRIPTION
Add a default false value for the allowImport optional field in the ContentLibrary CRD.