### PR TITLE
Remove default localObjectRef values

### DIFF
--- a/api/v1alpha1/contentlibrary_types.go
+++ b/api/v1alpha1/contentlibrary_types.go
@@ -160,6 +160,7 @@ func (contentLibrary *ContentLibrary) SetConditions(conditions Conditions) {
 // +kubebuilder:printcolumn:name="vSphereName",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.type"
 // +kubebuilder:printcolumn:name="Writable",type="boolean",JSONPath=".spec.writable"
+// +kubebuilder:printcolumn:name="AllowImport",type="boolean",JSONPath=".spec.allowImport"
 // +kubebuilder:printcolumn:name="StorageType",type="string",JSONPath=".status.storageBacking.type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/api/v1alpha1/contentlibraryitemimportrequest_types.go
+++ b/api/v1alpha1/contentlibraryitemimportrequest_types.go
@@ -45,7 +45,6 @@ type ContentLibraryItemImportRequestTarget struct {
 
 	// Library contains information about the library in which the library item
 	// will be created in vSphere.
-	// +kubebuilder:default={apiVersion: imageregistry.vmware.com/v1alpha1, kind: ContentLibraryItem}
 	// +required
 	Library LocalObjectRef `json:"library"`
 }


### PR DESCRIPTION
Since the LocalObjectRef has all 3 fields as required, we can't set default values for only 2 sub-fields.
Added allowImport print column to CL CR.

Testing Done:
Applied the yaml on a Supervisor cluster.
customresourcedefinition.apiextensions.k8s.io/contentlibraryitemimportrequests.imageregistry.vmware.com unchanged