### PR TITLE
Revert changes to the NameAndKindRef

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -10,6 +10,7 @@ type NameAndKindRef struct {
 	// Kind is a string value representing the kind of resource to which this
 	// object refers.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
 	Kind string `json:"kind"`
 
 	// Name refers to a unique resource in the current namespace.


### PR DESCRIPTION
The Kind field was changed to required accidentally as part of the change https://github.com/vmware-tanzu/image-registry-operator-api/commit/95d0df7ef3b0722bb518078632df742ac3a5a0a2#diff-0702ede917ee437555d00c32619d913b80dbf25db68f4c3c33df0212cf792d5b.

Reverting it.