### PR TITLE
add condition reason for upload session expired

### DIFF
--- a/api/v1alpha1/condition_constants.go
+++ b/api/v1alpha1/condition_constants.go
@@ -69,6 +69,9 @@ const (
 	// UploadFailureReason documents that uploading files to the target content library item has failed.
 	UploadFailureReason = "UploadFailure"
 
+	// UploadSessionExpiredReason documents that the uploading session for this ContentLibraryItemImportRequest has expired.
+	UploadSessionExpiredReason = "UploadSessionExpired"
+
 	// TargetLibraryItemNotReadyReason documents that the target ContentLibraryItem resource is not in ready status yet.
 	TargetLibraryItemNotReadyReason = "TargetLibraryItemNotReady"
 )


### PR DESCRIPTION
Separate upload session expired reason is needed as it should be a terminal state for the import.

Testing Done:
make targets  pass