### PR TITLE
Add optional ssl certificate to item import source

### DIFF
--- a/api/v1alpha1/condition_constants.go
+++ b/api/v1alpha1/condition_constants.go
@@ -40,13 +40,16 @@ const (
 	// SourceURLInvalidReason documents that the source URL specified in the ContentLibraryItemImportRequest is invalid.
 	SourceURLInvalidReason = "SourceURLInvalid"
 
-	// SourceSchemeInvalidReason documents that the scheme in the source URL specified in the
+	// SourceURLSchemeInvalidReason documents that the scheme in the source URL specified in the
 	// ContentLibraryItemImportRequest is invalid.
-	SourceSchemeInvalidReason = "SourceSchemeInvalid"
+	SourceURLSchemeInvalidReason = "SourceURLSchemeInvalid"
 
-	// SourceHostInvalidReason documents that the host in the source URL specified in the
+	// SourceURLHostInvalidReason documents that the host in the source URL specified in the
 	// ContentLibraryItemImportRequest is invalid.
-	SourceHostInvalidReason = "SourceHostInvalid"
+	SourceURLHostInvalidReason = "SourceURLHostInvalid"
+
+	// SourceSSLCertificateUntrustedReason documents that the SSL certificate served at the source URL is not trusted by vSphere.
+	SourceSSLCertificateUntrustedReason = "SourceSSLCertificateUntrusted"
 
 	// TargetLibraryInvalidReason documents that the target ContentLibrary specified in the
 	// ContentLibraryItemImportRequest is invalid.

--- a/api/v1alpha1/contentlibraryitemimportrequest_types.go
+++ b/api/v1alpha1/contentlibraryitemimportrequest_types.go
@@ -36,6 +36,14 @@ type ContentLibraryItemImportRequestSource struct {
 	// condition will become false in the status.
 	// +required
 	URL string `json:"url"`
+
+	// PEM encoded SSL Certificate for this endpoint specified by the URL. It is only used for HTTPS connections.
+	// If set, the remote endpoint's SSL certificate is only accepted if it matches this certificate, and no other
+	// certificate validation is performed.
+	// If unset, the remote endpoint's SSL certificate must be trusted by vSphere trusted root CA certificates,
+	// otherwise the SSL certification verification may fail and thus fail the import request.
+	// +optional
+	SSLCertificate string `json:"sslCertificate,omitempty"`
 }
 
 // ContentLibraryItemImportRequestTargetItem contains the specification of the target
@@ -55,7 +63,10 @@ type ContentLibraryItemImportRequestTargetItem struct {
 
 	// Type is the type of the new content library item that will be created in vSphere.
 	// Currently only ContentLibraryItemTypeOvf is supported, if it is omitted or other item type
-	// is specified, the TargetValid condition will become false in the status.
+	// is specified, the TargetValid condition will become false in the status. For the item type
+	// of ContentLibraryItemTypeOvf, it is required that the default OVF security policy is configured
+	// on the target content library for the import request, otherwise the TargetValid condition will
+	// become false in the status.
 	// +optional
 	Type ContentLibraryItemType `json:"type,omitempty"`
 }

--- a/hack/samples/go.mod
+++ b/hack/samples/go.mod
@@ -2,8 +2,6 @@ module github.com/vmware-tanzu/image-registry-operator-api/hack/samples
 
 go 1.21
 
-toolchain go1.21.6
-
 // The generated client is not part of the release, so point to the local version that includes the generated code
 // Note also that image-registry-operator-api is not specified in require the samples automatically pull in the latest
 replace github.com/vmware-tanzu/image-registry-operator-api => ../../../image-registry-operator-api


### PR DESCRIPTION
Add sslCertificate to ContentLibraryItemImportRequest source so that client can specify it if client trusts the certificate, otherwise the ssl certificate at the url must be trusted by vSphere root CAs or fail.

Testing Done:
make targets pass