### PR TITLE
Commit generated CRDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: ci
+
+env:
+  # This value is usually commented out, allowing the go-version-file
+  # directive to pull the Go version from the go.mod file. However,
+  # sometimes we need to explicitly override the Go version, ex. CVEs,
+  # when it is not possible to update the go.mod version yet, ex. the
+  # internal builds do not yet support that version of Go.
+  GO_VERSION: ""
+
+on:
+  pull_request:
+    branches:
+    - main
+    - 'release/**'
+  push:
+    branches:
+    - main
+
+jobs:
+
+  verify-go-modules:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Run go mod tidy
+      run: make modules
+    - name: Verify go modules have not changed
+      run: git diff --exit-code
+    - name: Run go mod download
+      run: make modules-download
+
+  verify-codegen:
+    needs:
+    - verify-go-modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Verify codegen
+      run: make verify-codegen
+
+  lint-go:
+    needs:
+    - verify-go-modules
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Setup the cache for golangci-lint
+      uses: actions/cache@v4
+      with:
+        key: golangci-lint-${{ runner.os }}-go${{ env.GO_VERSION }}-${{ hashFiles('go.sum', 'hack/tools/go.sum') }}
+        path: |
+          ~/.cache/golangci-lint
+          hack/tools/bin/golangci-lint
+    - name: Lint Go
+      run: make lint-go-full

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ vendor
 *.swo
 *~
 
-# generated config files
-config/
-

--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,7 @@ clean-bin: ## Remove all generated binaries
 .PHONY: clean-crd
 clean-crd: ## Remove all generated crds
 	rm -rf config/crd
+
+.PHONY: verify-codegen
+verify-codegen: ## Verify generated code
+	hack/verify-codegen.sh

--- a/config/crd/bases/imageregistry.vmware.com_clustercontentlibraries.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_clustercontentlibraries.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: clustercontentlibraries.imageregistry.vmware.com
+spec:
+  group: imageregistry.vmware.com
+  names:
+    kind: ClusterContentLibrary
+    listKind: ClusterContentLibraryList
+    plural: clustercontentlibraries
+    shortNames:
+    - cclib
+    singular: clustercontentlibrary
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: vSphereName
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.storageBacking.type
+      name: StorageType
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterContentLibrary is the schema for the cluster scoped content library API.
+          Currently, ClusterContentLibrary is immutable to end users.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterContentLibrarySpec defines the desired state of a
+              ClusterContentLibrary.
+            properties:
+              resourceNamingStrategy:
+                description: |-
+                  ResourceNamingStrategy defines the naming strategy for item resources in this content library. If not specified,
+                  naming strategy FROM_ITEM_ID will be used to generate item resource names. This field is immutable.
+                enum:
+                - FROM_ITEM_ID
+                - PREFER_ITEM_SOURCE_ID
+                type: string
+              uuid:
+                description: UUID is the identifier which uniquely identifies the
+                  library in vCenter. This field is immutable.
+                type: string
+            required:
+            - uuid
+            type: object
+          status:
+            description: ContentLibraryStatus defines the observed state of ContentLibrary.
+            properties:
+              conditions:
+                description: Conditions describes the current condition information
+                  of the ContentLibrary.
+                items:
+                  description: Condition defines an observation of an Image Registry
+                    Operator API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              creationTime:
+                description: CreationTime indicates the date and time when this library
+                  was created in vCenter.
+                format: date-time
+                type: string
+              description:
+                description: Description is a human-readable description for this
+                  library in vCenter.
+                type: string
+              lastModifiedTime:
+                description: |-
+                  LastModifiedTime indicates the date and time when this library was last updated in vCenter.
+                  This field is updated only when the library properties are changed. This field is not updated when a library
+                  item is added, modified or deleted or its content is changed.
+                format: date-time
+                type: string
+              lastSyncTime:
+                description: |-
+                  LastSyncTime indicates the date and time when this library was last synchronized in vCenter.
+                  This field applies only if the library is of the "Subscribed" Type.
+                format: date-time
+                type: string
+              name:
+                description: Name specifies the name of the content library in vCenter.
+                type: string
+              publishInfo:
+                description: Published indicates how the library is published so that
+                  it can be subscribed to by a remote subscribed library.
+                properties:
+                  URL:
+                    description: |-
+                      URL to which the library metadata is published by the vSphere Content Library Service.
+                      This value can be used to set the SubscriptionInfo.URL property when creating a subscribed library.
+                    type: string
+                  published:
+                    description: Published indicates if the local library is published
+                      so that it can be subscribed to by a remote subscribed library.
+                    type: boolean
+                required:
+                - URL
+                - published
+                type: object
+              securityPolicyID:
+                description: |-
+                  SecurityPolicyID defines the security policy applied to this library.
+                  Setting this field will make the library secure.
+                type: string
+              serverGUID:
+                description: ServerGUID indicates the unique identifier of the vCenter
+                  server where the library exists.
+                type: string
+              state:
+                description: State indicates the state of this library.
+                enum:
+                - Active
+                - InMaintenance
+                type: string
+              storageBacking:
+                description: StorageBacking indicates the default storage backing
+                  available for this library in vCenter.
+                properties:
+                  datastoreID:
+                    description: |-
+                      DatastoreID indicates the identifier of the datastore used to store the content
+                      in the library for the "Datastore" storageType in vCenter.
+                    type: string
+                  type:
+                    description: Type indicates the type of storage where the content
+                      would be stored.
+                    enum:
+                    - Datastore
+                    - Other
+                    type: string
+                required:
+                - type
+                type: object
+              subscriptionInfo:
+                description: |-
+                  SubscriptionInfo defines how the subscribed library synchronizes to a remote source.
+                  This field is populated only if Type=Subscribed.
+                properties:
+                  URL:
+                    description: |-
+                      URL of the endpoint where the metadata for the remotely published library is being served.
+                      The value from PublishInfo.URL of the published library should be used while creating a subscribed library.
+                    type: string
+                  automaticSync:
+                    description: AutomaticSync indicates whether the library should
+                      participate in automatic library synchronization.
+                    type: boolean
+                  onDemand:
+                    description: OnDemand indicates whether a library item’s content
+                      will be synchronized only on demand.
+                    type: boolean
+                required:
+                - URL
+                - automaticSync
+                - onDemand
+                type: object
+              type:
+                description: ContentLibraryType is a constant type that indicates
+                  the type of a content library in vCenter.
+                enum:
+                - Local
+                - Subscribed
+                type: string
+              version:
+                description: |-
+                  Version is a number that can identify metadata changes. This value is incremented when the library
+                  properties such as name or description are changed in vCenter.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/imageregistry.vmware.com_clustercontentlibraryitems.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_clustercontentlibraryitems.yaml
@@ -1,0 +1,275 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: clustercontentlibraryitems.imageregistry.vmware.com
+spec:
+  group: imageregistry.vmware.com
+  names:
+    kind: ClusterContentLibraryItem
+    listKind: ClusterContentLibraryItemList
+    plural: clustercontentlibraryitems
+    shortNames:
+    - cclitem
+    singular: clustercontentlibraryitem
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: vSphereName
+      type: string
+    - jsonPath: .status.contentLibraryRef.name
+      name: ClusterContentLibraryRef
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.cached
+      name: Cached
+      type: boolean
+    - jsonPath: .status.sizeInBytes
+      name: SizeInBytes
+      type: string
+    - jsonPath: .status.securityCompliance
+      name: SecurityCompliant
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterContentLibraryItem is the schema for the content library item API at the cluster scope.
+          Currently, ClusterContentLibraryItem is immutable to end users.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContentLibraryItemSpec defines the desired state of a ContentLibraryItem.
+            properties:
+              uuid:
+                description: UUID is the identifier which uniquely identifies the
+                  library item in vCenter. This field is immutable.
+                type: string
+            required:
+            - uuid
+            type: object
+          status:
+            description: ContentLibraryItemStatus defines the observed state of ContentLibraryItem.
+            properties:
+              cached:
+                default: false
+                description: Cached indicates if the library item files are on storage
+                  in vCenter.
+                type: boolean
+              certificateVerificationInfo:
+                description: CertificateVerificationInfo shows the certificate verification
+                  status and the signing certificate.
+                properties:
+                  certChain:
+                    description: CertChain shows the signing certificate chain in
+                      base64 encoding if the library item is signed.
+                    items:
+                      type: string
+                    type: array
+                  status:
+                    description: Status shows the certificate verification status
+                      of the library item.
+                    enum:
+                    - NOT_AVAILABLE
+                    - VERIFIED
+                    - INTERNAL
+                    - VERIFICATION_FAILURE
+                    - VERIFICATION_IN_PROGRESS
+                    - UNTRUSTED
+                    type: string
+                type: object
+              conditions:
+                description: Conditions describes the current condition information
+                  of the ContentLibraryItem.
+                items:
+                  description: Condition defines an observation of an Image Registry
+                    Operator API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentLibraryRef:
+                description: ContentLibraryRef refers to the ContentLibrary custom
+                  resource that this item belongs to.
+                properties:
+                  kind:
+                    description: |-
+                      Kind is a string value representing the kind of resource to which this
+                      object refers.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - name
+                type: object
+              contentVersion:
+                description: |-
+                  ContentVersion indicates the version of the library item content in vCenter.
+                  This value is incremented when the files comprising the content library item are changed in vCenter.
+                type: string
+              creationTime:
+                description: CreationTime indicates the date and time when this library
+                  item was created in vCenter.
+                format: date-time
+                type: string
+              description:
+                description: Description is a human-readable description for this
+                  library item.
+                type: string
+              fileInfo:
+                description: FileInfo represents zero, one or more files belonging
+                  to the content library item in vCenter.
+                items:
+                  description: FileInfo represents the information of a file in a
+                    content library item in vCenter.
+                  properties:
+                    cached:
+                      default: false
+                      description: Cached indicates if the library item file is on
+                        storage in vCenter.
+                      type: boolean
+                    name:
+                      description: Name specifies the name of the file in vCenter.
+                      type: string
+                    sizeInBytes:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: SizeInBytes indicates the library item file size
+                        in bytes on storage in vCenter.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storageURI:
+                      description: |-
+                        StorageURI identifies the file on the storage backing. It is specific to
+                        the storage backing and available after the file is cached in vCenter.
+                        This URL is useful for creating a device that is backed by this file
+                        (i.e. mounting an ISO file via a virtual CD-ROM device).
+                      type: string
+                    version:
+                      description: |-
+                        Version indicates the version of the library item file in vCenter.
+                        This value is incremented when a new copy of the file is uploaded to vCenter.
+                      type: string
+                  required:
+                  - cached
+                  - name
+                  - sizeInBytes
+                  - version
+                  type: object
+                type: array
+              lastModifiedTime:
+                description: |-
+                  LastModifiedTime indicates the date and time when this library item was last updated in vCenter.
+                  This field is updated when the library item properties are changed or the file content is changed.
+                format: date-time
+                type: string
+              lastSyncTime:
+                description: |-
+                  LastSyncTime indicates the date and time when this library item was last synchronized in vCenter.
+                  This field applies only to the library items belonging to the library of Type=Subscribed.
+                format: date-time
+                type: string
+              metadataVersion:
+                description: |-
+                  MetadataVersion indicates the version of the library item metadata in vCenter.
+                  This value is incremented when the library item properties such as name or description are changed in vCenter.
+                type: string
+              name:
+                description: Name specifies the name of the content library item in
+                  vCenter specified by the user.
+                type: string
+              securityCompliance:
+                description: SecurityCompliance shows the security compliance of the
+                  library item.
+                type: boolean
+              sizeInBytes:
+                anyOf:
+                - type: integer
+                - type: string
+                description: SizeInBytes indicates the library item size in bytes
+                  on storage in vCenter.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              sourceID:
+                description: SourceID indicates the source identifier of the library
+                  item if the item belongs to a subscribed content library.
+                type: string
+              type:
+                description: Type indicates the type of the library item in vCenter.
+                enum:
+                - OVF
+                - ISO
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/imageregistry.vmware.com_contentlibraries.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_contentlibraries.yaml
@@ -1,0 +1,255 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: contentlibraries.imageregistry.vmware.com
+spec:
+  group: imageregistry.vmware.com
+  names:
+    kind: ContentLibrary
+    listKind: ContentLibraryList
+    plural: contentlibraries
+    shortNames:
+    - clib
+    singular: contentlibrary
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: vSphereName
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .spec.writable
+      name: Writable
+      type: boolean
+    - jsonPath: .spec.allowImport
+      name: AllowImport
+      type: boolean
+    - jsonPath: .status.storageBacking.type
+      name: StorageType
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ContentLibrary is the schema for the content library API.
+          Currently, ContentLibrary is immutable to end users.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContentLibrarySpec defines the desired state of a ContentLibrary.
+            properties:
+              allowImport:
+                default: false
+                description: |-
+                  AllowImport flag indicates if users can import OVF/OVA templates from remote HTTPS URLs
+                  as new content library items in this library.
+                type: boolean
+              resourceNamingStrategy:
+                description: |-
+                  ResourceNamingStrategy defines the naming strategy for item resources in this content library. If not specified,
+                  naming strategy FROM_ITEM_ID will be used to generate item resource names. This field is immutable.
+                enum:
+                - FROM_ITEM_ID
+                - PREFER_ITEM_SOURCE_ID
+                type: string
+              uuid:
+                description: UUID is the identifier which uniquely identifies the
+                  library in vCenter. This field is immutable.
+                type: string
+              writable:
+                description: Writable flag indicates if users can create new library
+                  items in this library.
+                type: boolean
+            required:
+            - uuid
+            - writable
+            type: object
+          status:
+            description: ContentLibraryStatus defines the observed state of ContentLibrary.
+            properties:
+              conditions:
+                description: Conditions describes the current condition information
+                  of the ContentLibrary.
+                items:
+                  description: Condition defines an observation of an Image Registry
+                    Operator API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              creationTime:
+                description: CreationTime indicates the date and time when this library
+                  was created in vCenter.
+                format: date-time
+                type: string
+              description:
+                description: Description is a human-readable description for this
+                  library in vCenter.
+                type: string
+              lastModifiedTime:
+                description: |-
+                  LastModifiedTime indicates the date and time when this library was last updated in vCenter.
+                  This field is updated only when the library properties are changed. This field is not updated when a library
+                  item is added, modified or deleted or its content is changed.
+                format: date-time
+                type: string
+              lastSyncTime:
+                description: |-
+                  LastSyncTime indicates the date and time when this library was last synchronized in vCenter.
+                  This field applies only if the library is of the "Subscribed" Type.
+                format: date-time
+                type: string
+              name:
+                description: Name specifies the name of the content library in vCenter.
+                type: string
+              publishInfo:
+                description: Published indicates how the library is published so that
+                  it can be subscribed to by a remote subscribed library.
+                properties:
+                  URL:
+                    description: |-
+                      URL to which the library metadata is published by the vSphere Content Library Service.
+                      This value can be used to set the SubscriptionInfo.URL property when creating a subscribed library.
+                    type: string
+                  published:
+                    description: Published indicates if the local library is published
+                      so that it can be subscribed to by a remote subscribed library.
+                    type: boolean
+                required:
+                - URL
+                - published
+                type: object
+              securityPolicyID:
+                description: |-
+                  SecurityPolicyID defines the security policy applied to this library.
+                  Setting this field will make the library secure.
+                type: string
+              serverGUID:
+                description: ServerGUID indicates the unique identifier of the vCenter
+                  server where the library exists.
+                type: string
+              state:
+                description: State indicates the state of this library.
+                enum:
+                - Active
+                - InMaintenance
+                type: string
+              storageBacking:
+                description: StorageBacking indicates the default storage backing
+                  available for this library in vCenter.
+                properties:
+                  datastoreID:
+                    description: |-
+                      DatastoreID indicates the identifier of the datastore used to store the content
+                      in the library for the "Datastore" storageType in vCenter.
+                    type: string
+                  type:
+                    description: Type indicates the type of storage where the content
+                      would be stored.
+                    enum:
+                    - Datastore
+                    - Other
+                    type: string
+                required:
+                - type
+                type: object
+              subscriptionInfo:
+                description: |-
+                  SubscriptionInfo defines how the subscribed library synchronizes to a remote source.
+                  This field is populated only if Type=Subscribed.
+                properties:
+                  URL:
+                    description: |-
+                      URL of the endpoint where the metadata for the remotely published library is being served.
+                      The value from PublishInfo.URL of the published library should be used while creating a subscribed library.
+                    type: string
+                  automaticSync:
+                    description: AutomaticSync indicates whether the library should
+                      participate in automatic library synchronization.
+                    type: boolean
+                  onDemand:
+                    description: OnDemand indicates whether a library item’s content
+                      will be synchronized only on demand.
+                    type: boolean
+                required:
+                - URL
+                - automaticSync
+                - onDemand
+                type: object
+              type:
+                description: ContentLibraryType is a constant type that indicates
+                  the type of a content library in vCenter.
+                enum:
+                - Local
+                - Subscribed
+                type: string
+              version:
+                description: |-
+                  Version is a number that can identify metadata changes. This value is incremented when the library
+                  properties such as name or description are changed in vCenter.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/imageregistry.vmware.com_contentlibraryitemimportrequests.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_contentlibraryitemimportrequests.yaml
@@ -1,0 +1,334 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: contentlibraryitemimportrequests.imageregistry.vmware.com
+spec:
+  group: imageregistry.vmware.com
+  names:
+    kind: ContentLibraryItemImportRequest
+    listKind: ContentLibraryItemImportRequestList
+    plural: contentlibraryitemimportrequests
+    shortNames:
+    - clitemimport
+    singular: contentlibraryitemimportrequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.target.library.name
+      name: ContentLibraryRef
+      type: string
+    - jsonPath: .status.itemRef.name
+      name: ContentLibraryItemRef
+      type: string
+    - jsonPath: .status.conditions[?(.type=='Complete')].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ContentLibraryItemImportRequest defines the information necessary to import a VM image
+          template as a ContentLibraryItem to a Content Library in vSphere.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ContentLibraryItemImportRequestSpec defines the desired state of a
+              ContentLibraryItemImportRequest.
+            properties:
+              source:
+                description: |-
+                  Source is the source of the import request which includes an external URL
+                  pointing to a VM image template.
+                  Source and Target will be immutable if the SourceValid and TargetValid conditions are true.
+                properties:
+                  checksum:
+                    description: |-
+                      Checksum contains the checksum algorithm and value calculated for the
+                      file specified in the URL. If omitted, the import request will not verify
+                      the checksum of the file.
+                    properties:
+                      algorithm:
+                        default: SHA256
+                        description: |-
+                          Algorithm is the algorithm used to calculate the checksum. Supported
+                          algorithms are "SHA256" and "SHA512". If omitted, "SHA256" will be used
+                          as the default algorithm.
+                        enum:
+                        - SHA256
+                        - SHA512
+                        type: string
+                      value:
+                        description: Value is the checksum value calculated by the
+                          specified algorithm.
+                        type: string
+                    required:
+                    - value
+                    type: object
+                  sslCertificate:
+                    description: |-
+                      PEM encoded SSL Certificate for this endpoint specified by the URL. It is only used for HTTPS connections.
+                      If set, the remote endpoint's SSL certificate is only accepted if it matches this certificate, and no other
+                      certificate validation is performed.
+                      If unset, the remote endpoint's SSL certificate must be trusted by vSphere trusted root CA certificates,
+                      otherwise the SSL certification verification may fail and thus fail the import request.
+                    type: string
+                  url:
+                    description: |-
+                      URL is the endpoint that points to a file that is to be imported as a new Content Library Item in
+                      the target vSphere Content Library. If the target item type is ContentLibraryItemTypeOvf, the URL
+                      should point to an OVF descriptor file (.ovf), an OVA file (.ova), or an ISO file (.iso). Otherwise,
+                      the SourceValid condition will become false in the status.
+                    type: string
+                required:
+                - url
+                type: object
+              target:
+                description: |-
+                  Target is the target of the import request which includes the content library item
+                  information and a ContentLibrary resource.
+                  Source and Target will be immutable if the SourceValid and TargetValid conditions are true.
+                properties:
+                  item:
+                    description: |-
+                      Item contains information about the content library item to which
+                      the template will be imported in vSphere.
+                      If omitted, the content library item will be created with the same name as the name
+                      of the image specified in the spec.source.url in the specified vSphere Content Library.
+                      If an item with the same name already exists in the specified vSphere Content Library,
+                      the TargetValid condition will become false in the status.
+                    properties:
+                      description:
+                        description: Description is a description for a vSphere Content
+                          Library Item.
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the new content library item that will be created in vSphere.
+                          If omitted, the content library item will be created with the same name as the name
+                          of the image specified in the spec.source.url in the specified vSphere Content Library.
+                          If an item with the same name already exists in the specified vSphere Content Library,
+                          the TargetValid condition will become false in the status.
+                        type: string
+                      type:
+                        description: |-
+                          Type is the type of the new content library item that will be created in vSphere.
+                          Currently only ContentLibraryItemTypeOvf is supported, if it is omitted or other item type
+                          is specified, the TargetValid condition will become false in the status. For the item type
+                          of ContentLibraryItemTypeOvf, it is required that the default OVF security policy is configured
+                          on the target content library for the import request, otherwise the TargetValid condition will
+                          become false in the status.
+                        type: string
+                    type: object
+                  library:
+                    description: |-
+                      Library contains information about the library in which the library item
+                      will be created in vSphere.
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an
+                          object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the kind of resource to which this
+                          object refers.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name refers to a unique resource in the current namespace.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                required:
+                - library
+                type: object
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished is the time-to-live duration for how long this
+                  resource will be allowed to exist once the import operation
+                  completes. After the TTL expires, the resource will be automatically
+                  deleted without the user having to take any direct action.
+                  If this field is unset then the request resource will not be
+                  automatically deleted. If this field is set to zero then the request
+                  resource is eligible for deletion immediately after it finishes.
+                format: int64
+                minimum: 0
+                type: integer
+            required:
+            - source
+            - target
+            type: object
+          status:
+            description: |-
+              ContentLibraryItemImportRequestStatus defines the observed state of a
+              ContentLibraryItemImportRequest.
+            properties:
+              completionTime:
+                description: |-
+                  CompletionTime represents time when the request was completed.
+                  The value of this field should be equal to the value of the
+                  LastTransitionTime for the status condition Type=Complete.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  Conditions describes the current condition information of the ContentLibraryItemImportRequest.
+                  The conditions present will be:
+                    * SourceValid
+                    * TargetValid
+                    * ContentLibraryItemCreated
+                    * TemplateUploaded
+                    * ContentLibraryItemReady
+                    * Complete
+                items:
+                  description: Condition defines an observation of an Image Registry
+                    Operator API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              fileUploadStatus:
+                description: FileUpload indicates the upload status of files belonging
+                  to the template.
+                properties:
+                  fileUploads:
+                    description: FileUploads list the transfer statuses of files being
+                      uploaded and tracked by the upload session.
+                    items:
+                      description: FileTransferStatus indicates the transfer status
+                        of a file belonging to a library item.
+                      properties:
+                        bytesTransferred:
+                          description: BytesTransferred indicates the number of bytes
+                            of this file that have been received by the server.
+                          format: int64
+                          type: integer
+                        errorMessage:
+                          description: ErrorMessage describes the details about the
+                            transfer error if the transfer status is error.
+                          type: string
+                        name:
+                          description: Name specifies the name of the file that is
+                            transferred.
+                          type: string
+                        size:
+                          description: |-
+                            Size indicates the file size in bytes as received by the server, this won't be available
+                            until the transfer status is ready.
+                          format: int64
+                          type: integer
+                        transferStatus:
+                          description: Status indicates the transfer status of the
+                            file.
+                          type: string
+                      required:
+                      - name
+                      - transferStatus
+                      type: object
+                    type: array
+                  sessionUUID:
+                    description: SessionUUID is the identifier that uniquely identifies
+                      the file upload session on the library item in vSphere.
+                    type: string
+                type: object
+              itemRef:
+                description: |-
+                  ItemRef is the reference to the target ContentLibraryItem resource of the import request.
+                  If the ContentLibraryItemImportRequest is deleted when the import operation fails or before
+                  the Complete condition is set to true, the import operation will be cancelled in vSphere
+                  and the corresponding vSphere Content Library Item will be deleted.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an
+                      object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the kind of resource to which this
+                      object refers.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              startTime:
+                description: |-
+                  StartTime represents time when the request was acknowledged by the
+                  controller.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/imageregistry.vmware.com_contentlibraryitems.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_contentlibraryitems.yaml
@@ -1,0 +1,275 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: contentlibraryitems.imageregistry.vmware.com
+spec:
+  group: imageregistry.vmware.com
+  names:
+    kind: ContentLibraryItem
+    listKind: ContentLibraryItemList
+    plural: contentlibraryitems
+    shortNames:
+    - clitem
+    singular: contentlibraryitem
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.name
+      name: vSphereName
+      type: string
+    - jsonPath: .status.contentLibraryRef.name
+      name: ContentLibraryRef
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.cached
+      name: Cached
+      type: boolean
+    - jsonPath: .status.sizeInBytes
+      name: SizeInBytes
+      type: string
+    - jsonPath: .status.securityCompliance
+      name: SecurityCompliant
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ContentLibraryItem is the schema for the content library item API.
+          Currently, ContentLibraryItem is immutable to end users.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContentLibraryItemSpec defines the desired state of a ContentLibraryItem.
+            properties:
+              uuid:
+                description: UUID is the identifier which uniquely identifies the
+                  library item in vCenter. This field is immutable.
+                type: string
+            required:
+            - uuid
+            type: object
+          status:
+            description: ContentLibraryItemStatus defines the observed state of ContentLibraryItem.
+            properties:
+              cached:
+                default: false
+                description: Cached indicates if the library item files are on storage
+                  in vCenter.
+                type: boolean
+              certificateVerificationInfo:
+                description: CertificateVerificationInfo shows the certificate verification
+                  status and the signing certificate.
+                properties:
+                  certChain:
+                    description: CertChain shows the signing certificate chain in
+                      base64 encoding if the library item is signed.
+                    items:
+                      type: string
+                    type: array
+                  status:
+                    description: Status shows the certificate verification status
+                      of the library item.
+                    enum:
+                    - NOT_AVAILABLE
+                    - VERIFIED
+                    - INTERNAL
+                    - VERIFICATION_FAILURE
+                    - VERIFICATION_IN_PROGRESS
+                    - UNTRUSTED
+                    type: string
+                type: object
+              conditions:
+                description: Conditions describes the current condition information
+                  of the ContentLibraryItem.
+                items:
+                  description: Condition defines an observation of an Image Registry
+                    Operator API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentLibraryRef:
+                description: ContentLibraryRef refers to the ContentLibrary custom
+                  resource that this item belongs to.
+                properties:
+                  kind:
+                    description: |-
+                      Kind is a string value representing the kind of resource to which this
+                      object refers.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name refers to a unique resource in the current namespace.
+                      More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                    type: string
+                required:
+                - name
+                type: object
+              contentVersion:
+                description: |-
+                  ContentVersion indicates the version of the library item content in vCenter.
+                  This value is incremented when the files comprising the content library item are changed in vCenter.
+                type: string
+              creationTime:
+                description: CreationTime indicates the date and time when this library
+                  item was created in vCenter.
+                format: date-time
+                type: string
+              description:
+                description: Description is a human-readable description for this
+                  library item.
+                type: string
+              fileInfo:
+                description: FileInfo represents zero, one or more files belonging
+                  to the content library item in vCenter.
+                items:
+                  description: FileInfo represents the information of a file in a
+                    content library item in vCenter.
+                  properties:
+                    cached:
+                      default: false
+                      description: Cached indicates if the library item file is on
+                        storage in vCenter.
+                      type: boolean
+                    name:
+                      description: Name specifies the name of the file in vCenter.
+                      type: string
+                    sizeInBytes:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: SizeInBytes indicates the library item file size
+                        in bytes on storage in vCenter.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storageURI:
+                      description: |-
+                        StorageURI identifies the file on the storage backing. It is specific to
+                        the storage backing and available after the file is cached in vCenter.
+                        This URL is useful for creating a device that is backed by this file
+                        (i.e. mounting an ISO file via a virtual CD-ROM device).
+                      type: string
+                    version:
+                      description: |-
+                        Version indicates the version of the library item file in vCenter.
+                        This value is incremented when a new copy of the file is uploaded to vCenter.
+                      type: string
+                  required:
+                  - cached
+                  - name
+                  - sizeInBytes
+                  - version
+                  type: object
+                type: array
+              lastModifiedTime:
+                description: |-
+                  LastModifiedTime indicates the date and time when this library item was last updated in vCenter.
+                  This field is updated when the library item properties are changed or the file content is changed.
+                format: date-time
+                type: string
+              lastSyncTime:
+                description: |-
+                  LastSyncTime indicates the date and time when this library item was last synchronized in vCenter.
+                  This field applies only to the library items belonging to the library of Type=Subscribed.
+                format: date-time
+                type: string
+              metadataVersion:
+                description: |-
+                  MetadataVersion indicates the version of the library item metadata in vCenter.
+                  This value is incremented when the library item properties such as name or description are changed in vCenter.
+                type: string
+              name:
+                description: Name specifies the name of the content library item in
+                  vCenter specified by the user.
+                type: string
+              securityCompliance:
+                description: SecurityCompliance shows the security compliance of the
+                  library item.
+                type: boolean
+              sizeInBytes:
+                anyOf:
+                - type: integer
+                - type: string
+                description: SizeInBytes indicates the library item size in bytes
+                  on storage in vCenter.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              sourceID:
+                description: SourceID indicates the source identifier of the library
+                  item if the item belongs to a subscribed content library.
+                type: string
+              type:
+                description: Type indicates the type of the library item in vCenter.
+                enum:
+                - OVF
+                - ISO
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Check if generated files are up to date
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+make generate || exit_code="${?}"
+if [ "${exit_code:-0}" -ne 0 ]; then
+
+  # Please note the following heredoc uses leading tabs to allow
+  # the contents to be indented with the if/fi statement. For
+  # more information on indenting heredocs, please see the section
+  # entitled "Multi-line message, with tabs suppressed" from The
+  # Linux Documentation Project (TLDP) at
+  # https://tldp.org/LDP/abs/html/here-docs.html.
+  cat <<-EOF
+	Please investigate why the target is failing by running the
+	following command locally from the root of the project:
+
+	    make generate
+
+	Thank you!
+	EOF
+
+  exit "${exit_code}"
+fi
+
+if git diff --exit-code; then
+  printf '\nCongratulations! Generated assets are up-to-date!\n'
+else
+  exit_code="${?}"
+
+  # Please note the following heredoc uses leading tabs to allow
+  # the contents to be indented with the if/fi statement. For
+  # more information on indenting heredocs, please see the section
+  # entitled "Multi-line message, with tabs suppressed" from The
+  # Linux Documentation Project (TLDP) at
+  # https://tldp.org/LDP/abs/html/here-docs.html.
+  cat <<-EOF
+	Please update generated assets before opening a pull request or
+	pushing new changes. To generate the assets, please run the
+	following command from the root of the project:
+
+	    make generate
+
+	Thank you!
+	EOF
+
+  exit "${exit_code}"
+fi


### PR DESCRIPTION
This patch adds support for committing the generated CRDs to verify whether or not they have changed via a GitHub workflow.

Please see [this example run](https://github.com/akutz/image-registry-operator-api/actions/runs/14574214777) from the included GitHub action to verify it works as expected.