### PR TITLE
Add Storagepolicy as new StorageBackingType

### DIFF
--- a/api/v1alpha2/contentlibrary_types.go
+++ b/api/v1alpha2/contentlibrary_types.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=Datastore;Other
+// +kubebuilder:validation:Enum=Datastore;Storagepolicy;Other
 
 // StorageBackingType is a constant type that indicates the type of the storage
 // backing for a content library in vCenter.
@@ -18,6 +18,10 @@ const (
 	// StorageBackingTypeDatastore indicates a content library backed by a
 	// datastore.
 	StorageBackingTypeDatastore StorageBackingType = "Datastore"
+	
+	// StorageBackingTypeStoragePolicy indicates a content library backed by a
+	// Storagepolicy.
+	StorageBackingTypeStoragePolicy StorageBackingType = "Storagepolicy"
 
 	// StorageBackingTypeOther indicates a content library backed by an NFS or
 	// SMB file system.

--- a/config/crd/bases/imageregistry.vmware.com_clustercontentlibraries.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_clustercontentlibraries.yaml
@@ -452,11 +452,17 @@ spec:
                         DatastoreID indicates the identifier of the datastore used to store the
                         content in the library for the "Datastore" storageType in vCenter.
                       type: string
+                    storagePolicyID:
+                      description: |-
+                        StoragePolicyID indicates the identifier of the storage policy used to store the
+                        content in the library for the "Storagepolicy" storageType in vCenter.
+                      type: string
                     type:
                       description: Type indicates the type of storage where the content
                         would be stored.
                       enum:
                       - Datastore
+                      - Storagepolicy
                       - Other
                       type: string
                   required:

--- a/config/crd/bases/imageregistry.vmware.com_contentlibraries.yaml
+++ b/config/crd/bases/imageregistry.vmware.com_contentlibraries.yaml
@@ -493,11 +493,17 @@ spec:
                         DatastoreID indicates the identifier of the datastore used to store the
                         content in the library for the "Datastore" storageType in vCenter.
                       type: string
+                    storagePolicyID:
+                      description: |-
+                        StoragePolicyID indicates the identifier of the storage policy used to store the
+                        content in the library for the "Storagepolicy" storageType in vCenter.
+                      type: string
                     type:
                       description: Type indicates the type of storage where the content
                         would be stored.
                       enum:
                       - Datastore
+                      - Storagepolicy
                       - Other
                       type: string
                   required:


### PR DESCRIPTION
As part of new feature in VC CL, we want to support new StorageBackingType Storagepolicy. Ref: https://vmw-confluence.broadcom.net/spaces/CON/pages/2276266153/API+Review+-+CL+Storage+policy+backing+support